### PR TITLE
Provide access to request and response headers

### DIFF
--- a/README
+++ b/README
@@ -75,6 +75,12 @@ METHODS
 
          $api->del('/objects/first');
 
+   response
+        Returns the HTTP::Response object for the last response
+
+   header
+        Returns the list of header names or the value(s) of a specific header in the last response.
+
    errstr
        Returns the current error string for the last call.
 

--- a/lib/JSON/API.pm
+++ b/lib/JSON/API.pm
@@ -9,7 +9,7 @@ use URI::Encode qw/uri_encode/;
 BEGIN {
 	use Exporter ();
 	use vars qw($VERSION @ISA @EXPORT @EXPORT_OK %EXPORT_TAGS);
-	$VERSION     = '1.1.0';
+	$VERSION     = v1.1.0;
 	@ISA         = qw(Exporter);
 	#Give a hoot don't pollute, do not export more than needed by default
 	@EXPORT      = qw();


### PR DESCRIPTION
Adds optional argument to get, put, post and del that allows specifying additional HTTP headers.

Provides header method to list and return headers in response.

Provides response method to return the HTTP::Response object.

Treats HTTP_NOT_MODIFIED as a no-content success return.

fixes #1
