### PR TITLE
Add predecode hook

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl module JSON::API
 
+1.1.1 Thu Jun 27 21:32:23 2019
+    - Add predecode hook
+
 1.1.0 Sun Oct 23 11:36:00 2016
     - Added support for customizing and retrieving reqest/response headers
     - Added support for accessing the raw HTTP response object after issuing

--- a/README
+++ b/README
@@ -43,6 +43,10 @@ METHODS
 
            Specifying debug => 1 in the parameters hash will also enable debugging output within JSON::API.
 
+           Additionally you can specify predecodehook in the parameters hash with a reference to a subroutine. The subroutine will then be called with the received raw content as only
+           parameter before it is decoded. It then can preprocess the content e.g. alter it to be valid json. An example use case for this is calling a JSON API that prefixes the json with garbage
+           to prevent CSRF. The pre-decode hook can then strip the garbage from the raw content before the JSON data is being decoded.
+
    get|post|put|del
        Perform an HTTP action (GET|POST|PUT|DELETE) against the given API. All methods take the path to the API endpoint as the first parameter. The put() and post() methods also accept a second data
        parameter, which should be a reference to be serialized into JSON for POST/PUTing to the endpoint.

--- a/lib/JSON/API.pm
+++ b/lib/JSON/API.pm
@@ -112,6 +112,8 @@ sub _decode
 	$self->_debug("Deserializing JSON");
 	my $obj = undef;
 	eval {
+		$json = $self->{predecodehook}->($json)
+			 if defined($self->{predecodehook});
 		$obj = from_json($json);
 		$self->_debug("Deserializing successful:",Dumper($obj));
 	} or do {
@@ -131,7 +133,7 @@ sub new
 	return undef unless $base_url;
 
 	my %ua_opts = %parameters;
-	map { delete $parameters{$_}; } qw(user pass realm debug);
+	map { delete $parameters{$_}; } qw(user pass realm debug predecodehook);
 
 	my $ua = LWP::UserAgent->new(%parameters);
 
@@ -141,6 +143,7 @@ sub new
 				has_error    => 0,
 				error_string => '',
 				debug        => $ua_opts{debug},
+				predecodehook => $ua_opts{predecodehook},
 		}, ref ($class) || $class);
 
 	my $server = $self->_server($base_url);
@@ -284,6 +287,14 @@ for authentication to work properly.
 
 Specifying debug => 1 in the parameters hash will also enable debugging output
 within JSON::API.
+
+Additionally you can specify predecodehook in the parameters hash with a
+reference to a subroutine. The subroutine will then be called with the received
+raw content as only parameter before it is decoded. It then can preprocess the
+content e.g. alter it to be valid json. An example use case for this is calling
+a JSON API that prefixes the json with garbage to prevent CSRF. The pre-decode
+hook can then strip the garbage from the raw content before the JSON data is
+being decoded.
 
 =back
 


### PR DESCRIPTION
This change adds the possibility to let the application using this library to
preprocess the content of the http response. This is especially necessary for
APIs that prefix their answer with garbage to prevent CSRF.